### PR TITLE
Resize the satellite map to fit the page

### DIFF
--- a/webapp/WEB-INF/jsp/satmap/main.jsp
+++ b/webapp/WEB-INF/jsp/satmap/main.jsp
@@ -1,28 +1,30 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <h2>Current Satellite Position</h2>
 <br>
-<c:choose>
-	<c:when test="${satelliteId == 1}">
-		<script>
-			var norad = '40074';
-			var size = 'small';
-			var allpasses = '1';
-			var minelevation = '0';
-		</script>
-		<script type="text/javascript"
-			src="http://www.n2yo.com/js/webtracker.js"></script>
-	</c:when>
-	<c:otherwise>
-		<script>
-			var norad = '39444';
-			var size = 'small';
-			var allpasses = '1';
-			var minelevation = '0';
-		</script>
-		<script type="text/javascript"
-			src="http://www.n2yo.com/js/webtracker.js"></script>
-	</c:otherwise>
-</c:choose>
+<div id="satmap">
+	<c:choose>
+		<c:when test="${satelliteId == 1}">
+			<script>
+				var norad = '40074';
+				var size = 'medium';
+				var allpasses = '1';
+				var minelevation = '0';
+			</script>
+			<script type="text/javascript"
+				src="http://www.n2yo.com/js/webtracker.js"></script>
+		</c:when>
+		<c:otherwise>
+			<script>
+				var norad = '39444';
+				var size = 'medium';
+				var allpasses = '1';
+				var minelevation = '0';
+			</script>
+			<script type="text/javascript"
+				src="http://www.n2yo.com/js/webtracker.js"></script>
+		</c:otherwise>
+	</c:choose>
+</div>
 <p>
 	<strong>We are indebted to Chip, N2YO for the supply of this
 		functionality. For more information on this widget and his other web

--- a/webapp/css/fcdw.css
+++ b/webapp/css/fcdw.css
@@ -9,7 +9,7 @@ Adapted: 20130330 - Dave Johnson, G4DPZ
 /* jQuery UI theme fix */
 .ui-widget, .ui-widget-content
 {
-    font-size : 13px; 
+    font-size : 13px;
     font-family: Arial, Helvetica, sans-serif;
     font-size: 13px;
     color: #BBBBBB;
@@ -104,7 +104,7 @@ hr {
     display: none;
 }
 
-#banner h1  
+#banner h1
 {
     width: 180px;
     height: 130px;
@@ -169,8 +169,8 @@ hr {
 	color: #FFFFFF;
 }
 
-#menu a:hover { 
-	text-decoration: none; 
+#menu a:hover {
+	text-decoration: none;
 	color: #48ACDE;
 }
 
@@ -182,7 +182,7 @@ hr {
 
 /* Page
 ************************************************/
-#page-wrap 
+#page-wrap
 {
     position: relative;
 	width: 860px;
@@ -197,7 +197,7 @@ hr {
 	padding-top: 16px;
 }
 
-img.banner 
+img.banner
 {
     float: right;
 }
@@ -245,7 +245,7 @@ img.banner
 
 /* Sponsors
 ************************************************/
-#sponsors-wrap 
+#sponsors-wrap
 {
     width: 860px;
 	margin: 12px auto 0px auto;
@@ -296,7 +296,12 @@ img.banner
 	color: #FFFFFF;
 }
 
-
+/* Satellite map
+************************************************/
+#satmap iframe {
+    height: 465px;
+    width: 600px;
+}
 
 /* MISC - TEMP
 ************************************************/


### PR DESCRIPTION
The height of the [satellite map](http://warehouse.funcube.org.uk/satmap.html?satelliteId=2) iframe is slightly smaller then needed, so it crops the "next pass" data:

<img width="440" alt="screenshot 2018-02-07 14 41 52" src="https://user-images.githubusercontent.com/145218/35920164-655bdba6-0c17-11e8-98d5-febea6a53c54.png">

This PR resizes the iframe area, fixing the next pass and stretching the map to the full page width:

<img width="623" alt="screenshot 2018-02-07 14 47 40" src="https://user-images.githubusercontent.com/145218/35920184-74e558ae-0c17-11e8-93f0-c332c5ba190b.png">
